### PR TITLE
Seem to remove both wonkiness - in CharacterInfo and Interface Options

### DIFF
--- a/DCSLayouts.lua
+++ b/DCSLayouts.lua
@@ -193,24 +193,24 @@ local function ShowCharacterStats(unit)
 			end
 			--print(count)
 		end
-		height = floor(height)
-		StatFrame:SetHeight(height)
-		--local statheight = StatFrame:GetHeight()
-		--local baseheight = CharacterFrameInsetRight:GetHeight()
-		--print(statheight, baseheight)
-		if count <= 24 then
+		
+	end
+	height = floor(height)
+	StatFrame:SetHeight(height)
+	--local statheight = StatFrame:GetHeight()
+	--local baseheight = CharacterFrameInsetRight:GetHeight()
+	if count <= 24 then
+		UpdateStatFrameWidth(191)
+		StatScrollFrame.ScrollBar:Hide()
+	else
+		local checked = gdbprivate.gdb.gdbdefaults.dejacharacterstatsScrollbarChecked
+		if checked.ScrollbarSetChecked == true then
+			UpdateStatFrameWidth(180)
+			StatScrollFrame.ScrollBar:Show()
+		else
 			UpdateStatFrameWidth(191)
 			StatScrollFrame.ScrollBar:Hide()
-		else
-			local checked = gdbprivate.gdb.gdbdefaults.dejacharacterstatsScrollbarChecked
-			if checked.ScrollbarSetChecked == true then
-				UpdateStatFrameWidth(180)
-				StatScrollFrame.ScrollBar:Show()
-			else
-				UpdateStatFrameWidth(191)
-				StatScrollFrame.ScrollBar:Hide()
-			end			
-		end
+		end			
 	end
 end
 


### PR DESCRIPTION
Movement of StatFrame stuff outside of for loop.
There are some other places where stuff happens in for loop when it , in my opinion, should be outside of it.