### PR TITLE
Green Box Fix

### DIFF
--- a/DCSDuraRepair.lua
+++ b/DCSDuraRepair.lua
@@ -223,7 +223,7 @@ gdbprivate.gdbdefaults.gdbdefaults.dejacharacterstatsShowDuraChecked = {
 
 local DCS_ShowDuraCheck = CreateFrame("CheckButton", "DCS_ShowDuraCheck", DejaCharacterStatsPanel, "InterfaceOptionsCheckButtonTemplate")
 	DCS_ShowDuraCheck:RegisterEvent("PLAYER_LOGIN")
-    DCS_ShowDuraCheck:RegisterEvent("UPDATE_INVENTORY_DURABILITY")
+    DCS_ShowDuraCheck:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
 	DCS_ShowDuraCheck:ClearAllPoints()
 	DCS_ShowDuraCheck:SetPoint("LEFT", 25, -75)
 	DCS_ShowDuraCheck:SetScale(1.25)
@@ -304,7 +304,7 @@ gdbprivate.gdbdefaults.gdbdefaults.dejacharacterstatsShowDuraTextureChecked = {
 
 local DCS_ShowDuraTextureCheck = CreateFrame("CheckButton", "DCS_ShowDuraTextureCheck", DejaCharacterStatsPanel, "InterfaceOptionsCheckButtonTemplate")
 	DCS_ShowDuraTextureCheck:RegisterEvent("PLAYER_LOGIN")
-    DCS_ShowDuraTextureCheck:RegisterEvent("UPDATE_INVENTORY_DURABILITY")
+    DCS_ShowDuraTextureCheck:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
 	DCS_ShowDuraTextureCheck:ClearAllPoints()
 	DCS_ShowDuraTextureCheck:SetPoint("LEFT", 25, -25)
 	DCS_ShowDuraTextureCheck:SetScale(1.25)
@@ -355,7 +355,7 @@ gdbprivate.gdbdefaults.gdbdefaults.dejacharacterstatsShowAverageRepairChecked = 
 
 local DCS_ShowAverageDuraCheck = CreateFrame("CheckButton", "DCS_ShowAverageDuraCheck", DejaCharacterStatsPanel, "InterfaceOptionsCheckButtonTemplate")
 	DCS_ShowAverageDuraCheck:RegisterEvent("PLAYER_LOGIN")
-    DCS_ShowAverageDuraCheck:RegisterEvent("UPDATE_INVENTORY_DURABILITY")
+    DCS_ShowAverageDuraCheck:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
 	DCS_ShowAverageDuraCheck:ClearAllPoints()
 	DCS_ShowAverageDuraCheck:SetPoint("LEFT", 25, -50)
 	DCS_ShowAverageDuraCheck:SetScale(1.25)
@@ -474,7 +474,7 @@ gdbprivate.gdbdefaults.gdbdefaults.dejacharacterstatsShowItemRepairChecked = {
 
 local DCS_ShowItemRepairCheck = CreateFrame("CheckButton", "DCS_ShowItemRepairCheck", DejaCharacterStatsPanel, "InterfaceOptionsCheckButtonTemplate")
 	DCS_ShowItemRepairCheck:RegisterEvent("PLAYER_LOGIN")
-    DCS_ShowItemRepairCheck:RegisterEvent("UPDATE_INVENTORY_DURABILITY")
+    DCS_ShowItemRepairCheck:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
 	DCS_ShowItemRepairCheck:ClearAllPoints()
 	DCS_ShowItemRepairCheck:SetPoint("LEFT", 25, -100)
 	DCS_ShowItemRepairCheck:SetScale(1.25)


### PR DESCRIPTION
Fix for the green box bug that occurs with durability bars. There is a
bug where UPDATE_INVENTORY_DURABILITY is not called when an item being
equipped on the paper doll has the same transmog as the item it is
replacing.

I have opted to use PLAYER_EQUIPMENT_CHANGED instead.

I didn't get to fully test as the servers went down. We can always
hookfunc the paperdoll frame opening to call PLAYER_EQUIPMENT_CHANGED.