### PR TITLE
Unit aura stat update

### DIFF
--- a/DCSLayouts.lua
+++ b/DCSLayouts.lua
@@ -658,7 +658,7 @@ end
 	
 local function DCS_DefaultStatsAnchors()
 	DCS_InterfaceOptConfigButton:UnregisterEvent("UNIT_AURA")
-
+	DCS_InterfaceOptConfigButton:UnregisterEvent("UPDATE_INVENTORY_DURABILITY")
 	--configMode = false --seems like those four lines are not needed. Leaving incase they ARE needed
 	--DCS_ConfigtooltipText = L["Unlock DCS"] 
 	--DCS_TableResetCheck:Hide()
@@ -684,9 +684,9 @@ local function DCS_DefaultStatsAnchors()
 end
 
 local function DCS_InterfaceOptionsStatsAnchors()
-	DCS_InterfaceOptConfigButton:RegisterEvent("UNIT_AURA")
-
 	if (DejaCharacterStatsPanel~=nil) then
+		DCS_InterfaceOptConfigButton:RegisterEvent("UNIT_AURA")
+		DCS_InterfaceOptConfigButton:RegisterEvent("UPDATE_INVENTORY_DURABILITY")
 		set_config_mode(true)
 				
 		StatScrollFrame:ClearAllPoints()

--- a/DCSLayouts.lua
+++ b/DCSLayouts.lua
@@ -657,6 +657,8 @@ local function DCS_ClassCrestBGCheck()
 end
 	
 local function DCS_DefaultStatsAnchors()
+	DCS_InterfaceOptConfigButton:UnregisterEvent("UNIT_AURA")
+
 	--configMode = false --seems like those four lines are not needed. Leaving incase they ARE needed
 	--DCS_ConfigtooltipText = L["Unlock DCS"] 
 	--DCS_TableResetCheck:Hide()
@@ -682,6 +684,8 @@ local function DCS_DefaultStatsAnchors()
 end
 
 local function DCS_InterfaceOptionsStatsAnchors()
+	DCS_InterfaceOptConfigButton:RegisterEvent("UNIT_AURA")
+
 	if (DejaCharacterStatsPanel~=nil) then
 		set_config_mode(true)
 				
@@ -798,6 +802,10 @@ local function DCS_InterfaceOptConfigButton_OnLeave(self)
 	DCS_InterfaceOptConfigButton:SetScript("OnEnter", DCS_InterfaceOptConfigButton_OnEnter)
 	DCS_InterfaceOptConfigButton:SetScript("OnLeave", DCS_InterfaceOptConfigButton_OnLeave)
 
+	DCS_InterfaceOptConfigButton:SetScript("OnEvent", function(self, event)
+				ShowCharacterStats("player")
+	end)
+	
 	DCS_InterfaceOptConfigButton:SetScript("OnMouseUp", function(self, button, up)
 		configMode = not configMode
 		if (configMode) then


### PR DESCRIPTION
Potential fix for when Interface Options stats do not update when buffs
occur. Add event trigger UNIT_AURA