### PR TITLE
Just cosmetic change, so all UnitPowerMax calls would have powerType as an argument

### DIFF
--- a/DCSTables.lua
+++ b/DCSTables.lua
@@ -199,8 +199,8 @@ DCS_TableData.StatData.EnhancementsCategory = {
 
 DCS_TableData.StatData.DCS_POWER = {
 	updateFunc = function(statFrame, unit)
-		powerToken = SPELL_POWER_MANA
-		local power = UnitPowerMax(unit,powerToken);
+		powerType = SPELL_POWER_MANA --changing here as well for similarity
+		local power = UnitPowerMax(unit,powerType);
 		local powerText = BreakUpLargeNumbers(power);
 		if power > 0 then
 			PaperDollFrame_SetLabelAndText(statFrame, MANA, powerText, false, power);


### PR DESCRIPTION
Seems like the fix for error was pushed by you on last days of March.