### PR TITLE
Removal of GCD mouse-over tooltip for haste

### DIFF
--- a/DCSDecimals.lua
+++ b/DCSDecimals.lua
@@ -3,21 +3,6 @@ local L = namespace.L 				--localization
 
 -- Decimal Check
 
-local function get_gcd(haste)
-	--TODO checks for cases when cooldown is not according to formula
-	--print("INT",LE_UNIT_STAT_INTELLECT)
-	--print("STR",LE_UNIT_STAT_STRENGTH)
-	--print("AGI",LE_UNIT_STAT_AGILITY)
-	--print(primary)
-	local spec = GetSpecialization();
-	local primaryStat = select(6, GetSpecializationInfo(spec, nil, nil, nil, UnitSex("player")));
-	local fn = "";
-	if (primaryStat == LE_UNIT_STAT_INTELLECT) then
-		fn = format("; Global CD %.2fs", 1.5/(1+haste/100))
-	end
-	return fn
-end
-
 local function DCS_Decimals(notinteger)
 	-- Crit Chance
 		local statformat
@@ -94,7 +79,7 @@ local function DCS_Decimals(notinteger)
 		-- PaperDollFrame_SetLabelAndText Format Change
 			PaperDollFrame_SetLabelAndText(statFrame, STAT_HASTE, format(hasteFormatString, format(statformat, haste)), false, haste);
 
-			statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE .. format(PAPERDOLLFRAME_TOOLTIP_FORMAT, STAT_HASTE) .. " " .. format(hasteFormatString, format("%.2f%%", haste)) .. get_gcd(haste) .. FONT_COLOR_CODE_CLOSE;
+			statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE .. format(PAPERDOLLFRAME_TOOLTIP_FORMAT, STAT_HASTE) .. " " .. format(hasteFormatString, format("%.2f%%", haste)) .. FONT_COLOR_CODE_CLOSE;
 
 			local _, class = UnitClass(unit);
 			statFrame.tooltip2 = _G["STAT_HASTE_"..class.."_TOOLTIP"];


### PR DESCRIPTION
No response to
https://mods.curse.com/addons/wow/dejacharacterstats?comment=601, the
called function is wrong (e.g, not capped at 0.75 s), and there's GCD
stat.