### PR TITLE
Low level mastery

### DIFF
--- a/DCSDecimals.lua
+++ b/DCSDecimals.lua
@@ -122,7 +122,7 @@ local function DCS_Decimals(notinteger)
 			--end
 			local color_mastery = STAT_MASTERY 
 			if (UnitLevel("player") < SHOW_MASTERY_LEVEL) then
-				color_mastery = "|cff7f7f7f" .. STAT_MASTERY .. "|r"
+				color_mastery = "|cff7f7f7f" .. color_mastery .. "|r"
 			end
 			local mastery = GetMasteryEffect();
 		-- PaperDollFrame_SetLabelAndText Format Change

--- a/DCSDecimals.lua
+++ b/DCSDecimals.lua
@@ -131,17 +131,21 @@ local function DCS_Decimals(notinteger)
 				statFrame:Hide();
 				return;
 			end
+			--if (UnitLevel("player") < SHOW_MASTERY_LEVEL) then
+			--	statFrame:Hide();
+			--	return;
+			--end
+			local color_mastery = STAT_MASTERY 
 			if (UnitLevel("player") < SHOW_MASTERY_LEVEL) then
-				statFrame:Hide();
-				return;
+				color_mastery = "|cff7f7f7f" .. STAT_MASTERY .. "|r"
 			end
-
 			local mastery = GetMasteryEffect();
 		-- PaperDollFrame_SetLabelAndText Format Change
-			PaperDollFrame_SetLabelAndText(statFrame, STAT_MASTERY, format(statformat, mastery), false, mastery);
+			PaperDollFrame_SetLabelAndText(statFrame, color_mastery, format(statformat, mastery), false, mastery);
 			statFrame.onEnterFunc = Mastery_OnEnter;
 			statFrame:Show();
 		end
+			
 
 	-- Leech (Lifesteal)
 		function PaperDollFrame_SetLifesteal(statFrame, unit)

--- a/DCSTables.lua
+++ b/DCSTables.lua
@@ -535,16 +535,20 @@ DCS_TableData.StatData.MASTERY_RATING = {
 			statFrame:Hide();
 			return;
 		end
+		local color_rating = "Mastery Rating" 
 		if (UnitLevel("player") < SHOW_MASTERY_LEVEL) then
-			statFrame.numericValue = 0;
-			statFrame:Hide();
-			return;
+			color_rating = "|cff7f7f7f" .. color_rating .. "|r"
 		end
+		--if (UnitLevel("player") < SHOW_MASTERY_LEVEL) then
+		--	statFrame.numericValue = 0;
+		--	statFrame:Hide();
+		--	return;
+		--end
 		local _, bonuscoeff = GetMasteryEffect();
 		local stat = CR_MASTERY
 		local rating = GetCombatRating(stat)
 		local percentage = format("%.2f",GetCombatRatingBonus(stat)*bonuscoeff)
-		PaperDollFrame_SetLabelAndText(statFrame, "Mastery Rating", rating, false, rating);
+		PaperDollFrame_SetLabelAndText(statFrame, color_rating, rating, false, rating);
 		statFrame.tooltip = HIGHLIGHT_FONT_COLOR_CODE.."Mastery Rating".." "..rating..FONT_COLOR_CODE_CLOSE;
 		statFrame.tooltip2 = format("Mastery Rating of %s increases mastery by %.2f%%", BreakUpLargeNumbers(rating), percentage);
 		statFrame:Show();


### PR DESCRIPTION
Display of mastery stat and rating for low level players. Also makes the text label grey if character has no benefit from mastery.