### PR TITLE
German repair total abbreviation

### DIFF
--- a/Localization/localization.deDE.lua
+++ b/Localization/localization.deDE.lua
@@ -120,7 +120,7 @@ if namespace.locale == "deDE" then
 	L["Movement Speed"] = "Lauftempo"
 	L["Bewegungsgeschwindigkeit"] = "Lauftempo"
 	L["Durability"] = "Haltbarkeit"
-	L["Repair Total"] = "Ges. Reparaturkosten"
+	L["Repair Total"] = "Reparaturkosten"
 
 -- ## Enhancements ##
 


### PR DESCRIPTION
Changed to "Reparaturkosten" from "Ges. Reparaturkosten" so it doesn't
run into the numerical display as much.