### PR TITLE
Artifact offhand ilvl fix

### DIFF
--- a/DCSDuraRepair.lua
+++ b/DCSDuraRepair.lua
@@ -691,8 +691,7 @@ gdbprivate.gdbdefaults.gdbdefaults.dejacharacterstatsShowItemLevelChecked = {
 }	
 
 local function DCS_Item_Level_Center()
-	local DCSMainHandSlot = GetDetailedItemLevelInfo(GetInventoryItemLink("player", (CharacterMainHandSlot:GetID())))
-	local DCSSecondaryHandSlot = GetDetailedItemLevelInfo(GetInventoryItemLink("player", (CharacterSecondaryHandSlot:GetID())))
+	local DCSDeriveArtILvl = 0
 	for _, v in ipairs(DCSITEM_SLOT_FRAMES) do
 		local itemLink = GetInventoryItemLink("player", v:GetID())
 		if not itemLink then
@@ -708,10 +707,14 @@ local function DCS_Item_Level_Center()
 				if(text and text ~= "") then
 					local value = tonumber(text:match(ITEM_LEVEL_PATTERN))
 					if value then
+						DCSDeriveArtILvl = DCSDeriveArtILvl + value 
+						print(DCSDeriveArtILvl)
 						local _, _, itemRarity = GetItemInfo(itemLink)
 						local r, g, b = GetItemQualityColor(itemRarity)
-							v.ilevel:SetTextColor(r, g, b)
+						v.ilevel:SetTextColor(r, g, b)
 						if (itemRarity == 6) then 	--ALL Artifact items. If there were Artifact legs they would get the same ilvl text, since only weapons and we want them to be the same, this works and we don't care.
+							local DCSMainHandSlot = GetDetailedItemLevelInfo(GetInventoryItemLink("player", (CharacterMainHandSlot:GetID())))
+							local DCSSecondaryHandSlot = GetDetailedItemLevelInfo(GetInventoryItemLink("player", (CharacterSecondaryHandSlot:GetID())))
 							if (DCSMainHandSlot >= DCSSecondaryHandSlot) then
 								v.ilevel:SetText(DCSMainHandSlot)
 							else

--- a/DCSDuraRepair.lua
+++ b/DCSDuraRepair.lua
@@ -695,24 +695,25 @@ local function DCS_Item_Level_Center()
 	local _, equipped = GetAverageItemLevel()
 	--equipped = round(equipped * 16)
 	equipped = equipped * 16 --in tested cases worked without rounding	
+	local ITEM_LEVEL_PATTERN = ITEM_LEVEL:gsub("%%d", "(%%d+)") --moving outside of the function might not be warranted but moving outside of for loop is
+	local tooltip = CreateFrame("GameTooltip", "DCSScanTooltip", nil, "GameTooltipTemplate") --TODO: use the same frame for both repairs and itemlevel
+	tooltip:SetOwner(UIParent, "ANCHOR_NONE")
 	for _, v in ipairs(DCSITEM_SLOT_FRAMES) do
 		local itemLink = GetInventoryItemLink("player", v:GetID())
 		if not itemLink then
 			v.ilevel:SetFormattedText("")
 		else
-			local ITEM_LEVEL_PATTERN = ITEM_LEVEL:gsub("%%d", "(%%d+)")
-			local tooltip = CreateFrame("GameTooltip", "iLevelScanTooltip", nil, "GameTooltipTemplate")
-				tooltip:SetOwner(UIParent, "ANCHOR_NONE")
-				tooltip:ClearLines()
-				tooltip:SetHyperlink(itemLink)
+			tooltip:ClearLines()
+			tooltip:SetHyperlink(itemLink)
 			for i = 2, tooltip:NumLines() do
-				local text = _G["iLevelScanTooltipTextLeft"..i]:GetText()
+				local text = _G["DCSScanTooltipTextLeft"..i]:GetText()
 				if(text and text ~= "") then
 					local value = tonumber(text:match(ITEM_LEVEL_PATTERN))
 					if value then
-						local _, _, itemRarity = GetItemInfo(itemLink)
-						local r, g, b = GetItemQualityColor(itemRarity)
-						v.ilevel:SetTextColor(r, g, b)
+						local _, _, itemRarity = GetItemInfo(itemLink) --least scope for itemRarity
+						--local r, g, b = GetItemQualityColor(itemRarity)
+						--v.ilevel:SetTextColor(r, g, b)
+						v.ilevel:SetTextColor(GetItemQualityColor(itemRarity))
 						if (itemRarity == 6) then 	--supposedly only artifacts after crucible return wrong ilvl
 							value = (equipped - summar_ilvl)/2
 						else

--- a/DCSDuraRepair.lua
+++ b/DCSDuraRepair.lua
@@ -691,7 +691,10 @@ gdbprivate.gdbdefaults.gdbdefaults.dejacharacterstatsShowItemLevelChecked = {
 }	
 
 local function DCS_Item_Level_Center()
-	local DCSDeriveArtILvl = 0
+	local summar_ilvl = 0
+	local _, equipped = GetAverageItemLevel()
+	--equipped = round(equipped * 16)
+	equipped = equipped * 16 --in tested cases worked without rounding	
 	for _, v in ipairs(DCSITEM_SLOT_FRAMES) do
 		local itemLink = GetInventoryItemLink("player", v:GetID())
 		if not itemLink then
@@ -707,22 +710,16 @@ local function DCS_Item_Level_Center()
 				if(text and text ~= "") then
 					local value = tonumber(text:match(ITEM_LEVEL_PATTERN))
 					if value then
-						DCSDeriveArtILvl = DCSDeriveArtILvl + value 
-						print(DCSDeriveArtILvl)
 						local _, _, itemRarity = GetItemInfo(itemLink)
 						local r, g, b = GetItemQualityColor(itemRarity)
 						v.ilevel:SetTextColor(r, g, b)
-						if (itemRarity == 6) then 	--ALL Artifact items. If there were Artifact legs they would get the same ilvl text, since only weapons and we want them to be the same, this works and we don't care.
-							local DCSMainHandSlot = GetDetailedItemLevelInfo(GetInventoryItemLink("player", (CharacterMainHandSlot:GetID())))
-							local DCSSecondaryHandSlot = GetDetailedItemLevelInfo(GetInventoryItemLink("player", (CharacterSecondaryHandSlot:GetID())))
-							if (DCSMainHandSlot >= DCSSecondaryHandSlot) then
-								v.ilevel:SetText(DCSMainHandSlot)
-							else
-								v.ilevel:SetText(DCSSecondaryHandSlot)
-							end
+						if (itemRarity == 6) then 	--supposedly only artifacts after crucible return wrong ilvl
+							value = (equipped - summar_ilvl)/2
 						else
-							v.ilevel:SetText(value)
+							summar_ilvl = summar_ilvl + value
 						end
+						v.ilevel:SetText("")
+						v.ilevel:SetText(value)
 					end
 				end
 			end
@@ -732,6 +729,8 @@ end
 
 local DCS_ShowItemLevelCheck = CreateFrame("CheckButton", "DCS_ShowItemLevelCheck", DejaCharacterStatsPanel, "InterfaceOptionsCheckButtonTemplate")
 	DCS_ShowItemLevelCheck:RegisterEvent("PLAYER_LOGIN")
+	DCS_ShowItemLevelCheck:RegisterEvent("player", "PLAYER_SPECIALIZATION_CHANGED")
+	DCS_ShowItemLevelCheck:RegisterEvent("player", "UNIT_INVENTORY_CHANGED")
 	DCS_ShowItemLevelCheck:ClearAllPoints()
 	--DCS_ShowItemLevelCheck:SetPoint("TOPLEFT", 30, -255)
 	DCS_ShowItemLevelCheck:SetPoint("TOPLEFT", "dcsItemsPanelCategoryFS", 7, -15)

--- a/DCSDuraRepair.lua
+++ b/DCSDuraRepair.lua
@@ -697,8 +697,11 @@ local function DCS_Item_Level_Center()
 			v.ilevel:SetFormattedText("")
 		else
 			local _, _, itemRarity = GetItemInfo(itemLink)
-			local effectiveLevel = GetDetailedItemLevelInfo(itemLink)
 			local r, g, b = GetItemQualityColor(itemRarity)
+			local effectiveLevel = GetDetailedItemLevelInfo(itemLink)
+			if (v == CharacterSecondaryHandSlot) and (itemRarity == 6) then
+				effectiveLevel = GetDetailedItemLevelInfo(GetInventoryItemLink("player", CharacterMainHandSlot:GetID()))
+			end
 			--print(itemLink, itemLevel)
 			v.ilevel:SetTextColor(r, g, b)
 			v.ilevel:SetText(effectiveLevel)

--- a/DCSDuraRepair.lua
+++ b/DCSDuraRepair.lua
@@ -691,20 +691,38 @@ gdbprivate.gdbdefaults.gdbdefaults.dejacharacterstatsShowItemLevelChecked = {
 }	
 
 local function DCS_Item_Level_Center()
+	local DCSMainHandSlot = GetDetailedItemLevelInfo(GetInventoryItemLink("player", (CharacterMainHandSlot:GetID())))
+	local DCSSecondaryHandSlot = GetDetailedItemLevelInfo(GetInventoryItemLink("player", (CharacterSecondaryHandSlot:GetID())))
 	for _, v in ipairs(DCSITEM_SLOT_FRAMES) do
 		local itemLink = GetInventoryItemLink("player", v:GetID())
 		if not itemLink then
 			v.ilevel:SetFormattedText("")
 		else
-			local _, _, itemRarity = GetItemInfo(itemLink)
-			local r, g, b = GetItemQualityColor(itemRarity)
-			local effectiveLevel = GetDetailedItemLevelInfo(itemLink)
-			if (v == CharacterSecondaryHandSlot) and (itemRarity == 6) then
-				effectiveLevel = GetDetailedItemLevelInfo(GetInventoryItemLink("player", CharacterMainHandSlot:GetID()))
+			local ITEM_LEVEL_PATTERN = ITEM_LEVEL:gsub("%%d", "(%%d+)")
+			local tooltip = CreateFrame("GameTooltip", "iLevelScanTooltip", nil, "GameTooltipTemplate")
+				tooltip:SetOwner(UIParent, "ANCHOR_NONE")
+				tooltip:ClearLines()
+				tooltip:SetHyperlink(itemLink)
+			for i = 2, tooltip:NumLines() do
+				local text = _G["iLevelScanTooltipTextLeft"..i]:GetText()
+				if(text and text ~= "") then
+					local value = tonumber(text:match(ITEM_LEVEL_PATTERN))
+					if value then
+						local _, _, itemRarity = GetItemInfo(itemLink)
+						local r, g, b = GetItemQualityColor(itemRarity)
+							v.ilevel:SetTextColor(r, g, b)
+						if (itemRarity == 6) then 	--ALL Artifact items. If there were Artifact legs they would get the same ilvl text, since only weapons and we want them to be the same, this works and we don't care.
+							if (DCSMainHandSlot >= DCSSecondaryHandSlot) then
+								v.ilevel:SetText(DCSMainHandSlot)
+							else
+								v.ilevel:SetText(DCSSecondaryHandSlot)
+							end
+						else
+							v.ilevel:SetText(value)
+						end
+					end
+				end
 			end
-			--print(itemLink, itemLevel)
-			v.ilevel:SetTextColor(r, g, b)
-			v.ilevel:SetText(effectiveLevel)
 		end
 	end
 end

--- a/DCSDuraRepair.lua
+++ b/DCSDuraRepair.lua
@@ -718,7 +718,6 @@ local function DCS_Item_Level_Center()
 						else
 							summar_ilvl = summar_ilvl + value
 						end
-						v.ilevel:SetText("")
 						v.ilevel:SetText(value)
 					end
 				end
@@ -729,8 +728,6 @@ end
 
 local DCS_ShowItemLevelCheck = CreateFrame("CheckButton", "DCS_ShowItemLevelCheck", DejaCharacterStatsPanel, "InterfaceOptionsCheckButtonTemplate")
 	DCS_ShowItemLevelCheck:RegisterEvent("PLAYER_LOGIN")
-	DCS_ShowItemLevelCheck:RegisterEvent("player", "PLAYER_SPECIALIZATION_CHANGED")
-	DCS_ShowItemLevelCheck:RegisterEvent("player", "UNIT_INVENTORY_CHANGED")
 	DCS_ShowItemLevelCheck:ClearAllPoints()
 	--DCS_ShowItemLevelCheck:SetPoint("TOPLEFT", 30, -255)
 	DCS_ShowItemLevelCheck:SetPoint("TOPLEFT", "dcsItemsPanelCategoryFS", 7, -15)
@@ -742,6 +739,7 @@ DCS_ShowItemLevelCheck:SetScript("OnEvent", function(self, ...)
 	showitemlevel = gdbprivate.gdb.gdbdefaults.dejacharacterstatsShowItemLevelChecked.ShowItemLevelSetChecked
 	self:SetChecked(showitemlevel)
 	DCS_Set_Dura_Item_Positions()
+	DCS_Item_Level_Center()
 end)
 
 DCS_ShowItemLevelCheck:SetScript("OnClick", function(self)
@@ -759,13 +757,14 @@ end)
 
 local DCS_ShowItemLevelChange = CreateFrame("Frame", "DCS_ShowItemLevelChange", UIParent)
 	DCS_ShowItemLevelChange:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
+	DCS_ShowItemLevelChange:RegisterEvent("PLAYER_SPECIALIZATION_CHANGED")
 	
 DCS_ShowItemLevelChange:SetScript("OnEvent", function(self, ...)
 	if PaperDollFrame:IsVisible() then
 		--print("PaperDollFrame:IsVisible")
 		if showitemlevel then
 		--print("showitemlevel")
-			DCS_Item_Level_Center()
+			C_Timer.After(0.25, DCS_Item_Level_Center) --Event fires before Artifact changes so we have to wait a fraction of a second.
 		else
 			for _, v in ipairs(DCSITEM_SLOT_FRAMES) do
 				v.ilevel:SetFormattedText("")


### PR DESCRIPTION
Artifacts were still now showing the correct ilvl on the offhands, even
with effective level. If you link the Artifact from the offhand it shows
the level as 750, even using item link, so effective level doesn;t
work...