### PR TITLE
Hide defense for non tanks

### DIFF
--- a/DCSLayouts.lua
+++ b/DCSLayouts.lua
@@ -62,8 +62,8 @@ local StatScrollFrame = CreateFrame("ScrollFrame", nil, CharacterFrameInsetRight
 	char_ctats_pane.EnhancementsCategory:SetParent(StatFrame)
 	char_ctats_pane.EnhancementsCategory:SetHeight(28)
 	char_ctats_pane.EnhancementsCategory.Background:SetHeight(28)
-	
-local DefaultData = DCS_TableData:MergeTable({
+
+local DefaultTankData = DCS_TableData:MergeTable({
     { statKey = "ItemLevelFrame" },
 	{ statKey = "GeneralCategory" },
         { statKey = "HEALTH" },
@@ -111,8 +111,56 @@ local DefaultData = DCS_TableData:MergeTable({
 		{ statKey = "DODGE_RATING", hideAt = 0 },
 		{ statKey = "PARRY_RATING", hideAt = 0 },
 })
-
-local ShownData = DefaultData
+local DefaultNonTankData = DCS_TableData:MergeTable({
+    { statKey = "ItemLevelFrame" },
+	{ statKey = "GeneralCategory" },
+        { statKey = "HEALTH" },
+        { statKey = "DCS_POWER" },
+        { statKey = "DCS_ALTERNATEMANA" },
+		{ statKey = "ARMOR" },
+        { statKey = "ITEMLEVEL", hidden = true },
+        { statKey = "MOVESPEED" },
+		{ statKey = "DURABILITY_STAT" },
+        { statKey = "REPAIR_COST" },
+	{ statKey = "AttributesCategory" },
+        { statKey = "STRENGTH" },
+        { statKey = "AGILITY" },
+        { statKey = "INTELLECT" },
+        { statKey = "STAMINA" },
+	{ statKey = "OffenseCategory" }, --Re-order before Enhancements to appear more logical.
+        { statKey = "ATTACK_DAMAGE" },
+        { statKey = "ATTACK_AP" },
+        { statKey = "DCS_ATTACK_ATTACKSPEED" },
+		{ statKey = "WEAPON_DPS" },
+        { statKey = "SPELLPOWER" },
+        { statKey = "MANAREGEN" },
+        { statKey = "ENERGY_REGEN" },
+        { statKey = "DCS_RUNEREGEN" },
+        { statKey = "FOCUS_REGEN" },		
+        { statKey = "GCD" },
+	{ statKey = "EnhancementsCategory" }, --Re-order after Offense to appear more logical.
+        { statKey = "CRITCHANCE", hideAt = 0 },
+		{ statKey = "HASTE", hideAt = 0 },
+        { statKey = "VERSATILITY", hideAt = 0 },
+        { statKey = "MASTERY", hideAt = 0 },
+        { statKey = "LIFESTEAL", hideAt = 0 },
+        { statKey = "AVOIDANCE", hideAt = 0 },
+	{ statKey = "DefenseCategory" },
+        { statKey = "DODGE", hideAt = 0 },
+        { statKey = "PARRY", hideAt = 0 },
+        { statKey = "BLOCK", hideAt = 0 },
+	{ statKey = "RatingCategory" },
+		{ statKey = "CRITCHANCE_RATING", hideAt = 0 },
+		{ statKey = "HASTE_RATING", hideAt = 0 },
+		{ statKey = "VERSATILITY_RATING", hideAt = 0 },
+		{ statKey = "MASTERY_RATING", hideAt = 0 },
+		{ statKey = "LIFESTEAL_RATING", hideAt = 0 },
+		{ statKey = "AVOIDANCE_RATING", hideAt = 0 },
+		{ statKey = "DODGE_RATING", hideAt = 0 },
+		{ statKey = "PARRY_RATING", hideAt = 0 },
+})
+--local ShownData = DefaultData
+local ShownData = DefaultNonTankData --TODO: find a reason why error during login with "local ShownData". Most probably too early PaperDollFrame_UpdateStats() calls due to DCS_configButton:RegisterEvent("UPDATE_INVENTORY_DURABILITY")
 
 for k, v in pairs(DCS_TableData.StatData) do
 	if (not v.frame) then
@@ -298,16 +346,19 @@ local function DCS_Table_Relevant()
 	local uniqueKey = UnitName("player") .. ":" .. GetRealmName() .. ":" .. GetSpecialization()
 	--print(uniqueKey)
 	--print("Select only relevant stats")
-	--ShownData = DCS_TableData:CopyTable(DefaultData)
-
+	local spec = GetSpecialization();
+	--print(spec)
+	local role = GetSpecializationRole(spec)
+	--print(role)
+	if role == "TANK" then
+		ShownData = DCS_TableData:CopyTable(DefaultTankData)
+	else
+		ShownData = DCS_TableData:CopyTable(DefaultNonTankData)
+	end
 	for _, v in ipairs(ShownData) do
 		if v.hidden then v.hidden = false end
 	end 
 
-	local spec = GetSpecialization();
-		--print(spec)
-	local role = GetSpecializationRole(spec)
-		--print(role)
 	local primaryStat = select(6, GetSpecializationInfo(spec, nil, nil, nil, UnitSex("player")));
 		--print(primaryStat)
     for _, v in ipairs(ShownData) do
@@ -340,7 +391,7 @@ local function DCS_Table_Relevant()
 		if role ~= "TANK" then
 				--print("Not Tank")
 			if v.statKey == "DefenseCategory" then v.hidden = true end --If not a tank then Defense category and its relevant stats are hidden.
-			if v.statKey == "ARMOR" then v.hidden = true end
+			--if v.statKey == "ARMOR" then v.hidden = true end
 			if v.statKey == "DODGE" then v.hidden = true end
 			if v.statKey == "PARRY" then v.hidden = true end
 			if v.statKey == "BLOCK" then v.hidden = true end
@@ -367,8 +418,15 @@ local function DCS_Table_Relevant()
 end
 
 local function DCS_Login_Initialization()
-	ShownData = DCS_TableData:CopyTable(DefaultData)
-	local uniqueKey = UnitName("player") .. ":" .. GetRealmName() .. ":" .. GetSpecialization()
+	local spec = GetSpecialization();
+		--print(spec)
+	local role = GetSpecializationRole(spec)
+	if role == "TANK" then
+		ShownData = DCS_TableData:CopyTable(DefaultTankData)
+	else
+		ShownData = DCS_TableData:CopyTable(DefaultNonTankData)
+	end
+	local uniqueKey = UnitName("player") .. ":" .. GetRealmName() .. ":" .. spec
 	--print(uniqueKey)
 	if (DCS_ClassSpecDB[uniqueKey]) then
 		if (ShownData.uniqueKey ~= uniqueKey) then
@@ -384,11 +442,19 @@ local function DCS_Login_Initialization()
 end
 
 local function DCS_Table_Reset()
-	local uniqueKey = UnitName("player") .. ":" .. GetRealmName() .. ":" .. GetSpecialization()
+	local temp
+	local spec = GetSpecialization();
+		--print(spec)
+	local role = GetSpecializationRole(spec)
+	if role == "TANK" then
+		temp = DCS_TableData:CopyTable(DefaultTankData)
+	else
+		temp = DCS_TableData:CopyTable(DefaultNonTankData)
+	end
+	local uniqueKey = UnitName("player") .. ":" .. GetRealmName() .. ":" .. spec
 	--print(uniqueKey)
 	--print("reseting just order of stata")
 	--ShownData = DCS_TableData:CopyTable(DefaultData)
-	local temp = DCS_TableData:CopyTable(DefaultData)
 	for _, v1 in ipairs(temp) do
 		for _, v2 in ipairs(ShownData) do
 			if v1.statKey == v2.statKey then

--- a/DCSLayouts.lua
+++ b/DCSLayouts.lua
@@ -117,7 +117,6 @@ local DefaultNonTankData = DCS_TableData:MergeTable({
         { statKey = "HEALTH" },
         { statKey = "DCS_POWER" },
         { statKey = "DCS_ALTERNATEMANA" },
-		{ statKey = "ARMOR" },
         { statKey = "ITEMLEVEL", hidden = true },
         { statKey = "MOVESPEED" },
 		{ statKey = "DURABILITY_STAT" },
@@ -127,6 +126,7 @@ local DefaultNonTankData = DCS_TableData:MergeTable({
         { statKey = "AGILITY" },
         { statKey = "INTELLECT" },
         { statKey = "STAMINA" },
+		{ statKey = "ARMOR" }, --Armor has always been an main attribute stat, except for tanks where it is a defense stat.
 	{ statKey = "OffenseCategory" }, --Re-order before Enhancements to appear more logical.
         { statKey = "ATTACK_DAMAGE" },
         { statKey = "ATTACK_AP" },

--- a/DCSLayouts.lua
+++ b/DCSLayouts.lua
@@ -78,14 +78,7 @@ local DefaultData = DCS_TableData:MergeTable({
         { statKey = "AGILITY" },
         { statKey = "INTELLECT" },
         { statKey = "STAMINA" },
-    { statKey = "EnhancementsCategory" },
-        { statKey = "CRITCHANCE", hideAt = 0 },
-		{ statKey = "HASTE", hideAt = 0 },
-        { statKey = "VERSATILITY", hideAt = 0 },
-        { statKey = "MASTERY", hideAt = 0 },
-        { statKey = "LIFESTEAL", hideAt = 0 },
-        { statKey = "AVOIDANCE", hideAt = 0 },
-	{ statKey = "AttackCategory" },
+	{ statKey = "OffenseCategory" }, --Re-order before Enhancements to appear more logical.
         { statKey = "ATTACK_DAMAGE" },
         { statKey = "ATTACK_AP" },
         { statKey = "DCS_ATTACK_ATTACKSPEED" },
@@ -96,6 +89,13 @@ local DefaultData = DCS_TableData:MergeTable({
         { statKey = "DCS_RUNEREGEN" },
         { statKey = "FOCUS_REGEN" },		
         { statKey = "GCD" },
+	{ statKey = "EnhancementsCategory" }, --Re-order after Offense to appear more logical.
+        { statKey = "CRITCHANCE", hideAt = 0 },
+		{ statKey = "HASTE", hideAt = 0 },
+        { statKey = "VERSATILITY", hideAt = 0 },
+        { statKey = "MASTERY", hideAt = 0 },
+        { statKey = "LIFESTEAL", hideAt = 0 },
+        { statKey = "AVOIDANCE", hideAt = 0 },
 	{ statKey = "DefenseCategory" },
         { statKey = "ARMOR" },
         { statKey = "DODGE", hideAt = 0 },
@@ -123,7 +123,7 @@ for k, v in pairs(DCS_TableData.StatData) do
 			if k == "GeneralCategory" then
 				v.frame.Title:SetText(L["General"])
 			end
-			if k == "AttackCategory" then
+			if k == "OffenseCategory" then
 				v.frame.Title:SetText(L["Offense"])
 			end
 			if k == "DefenseCategory" then
@@ -339,6 +339,8 @@ local function DCS_Table_Relevant()
 		end
 		if role ~= "TANK" then
 				--print("Not Tank")
+			if v.statKey == "DefenseCategory" then v.hidden = true end --If not a tank then Defense category and its relevant stats are hidden.
+			if v.statKey == "ARMOR" then v.hidden = true end
 			if v.statKey == "DODGE" then v.hidden = true end
 			if v.statKey == "PARRY" then v.hidden = true end
 			if v.statKey == "BLOCK" then v.hidden = true end
@@ -354,7 +356,7 @@ local function DCS_Table_Relevant()
 		if v.statKey == "PARRY_RATING" then v.hidden = true end
 		if v.statKey == "ITEMLEVEL" then v.hidden = true end
 		--if v.statKey == "GeneralCategory" then v.hidden = true end
-		--if v.statKey == "AttackCategory" then v.hidden = true end
+		--if v.statKey == "OffenseCategory" then v.hidden = true end
 		--if v.statKey == "DefenseCategory" then v.hidden = true end
 		if v.statKey == "RatingCategory" then v.hidden = true end --ratings are invisible, so the category is also hidden
 	end

--- a/DCSLayouts.lua
+++ b/DCSLayouts.lua
@@ -350,11 +350,6 @@ local function DCS_Table_Relevant()
 	--print(spec)
 	local role = GetSpecializationRole(spec)
 	--print(role)
-	if role == "TANK" then
-		ShownData = DCS_TableData:CopyTable(DefaultTankData)
-	else
-		ShownData = DCS_TableData:CopyTable(DefaultNonTankData)
-	end
 	for _, v in ipairs(ShownData) do
 		if v.hidden then v.hidden = false end
 	end 

--- a/DCSTables.lua
+++ b/DCSTables.lua
@@ -317,9 +317,9 @@ DCS_TableData.StatData.EnhancementsCategory = {
     updateFunc = function() end
 }
 
-DCS_TableData.StatData.AttackCategory = {
+DCS_TableData.StatData.OffenseCategory = {
     category   = true,
-    frame      = char_ctats_pane.AttackCategory,
+    frame      = char_ctats_pane.OffenseCategory,
     updateFunc = function()	end
 }
 


### PR DESCRIPTION
Hid the Defense category and its relevant stats for non tanks.

Changed AttackCategory to OffenseCategory to reduce confusion.